### PR TITLE
serrano-library: Add WrongArgumentError class

### DIFF
--- a/serrano-library/code/js/modules/exceptions.js
+++ b/serrano-library/code/js/modules/exceptions.js
@@ -38,3 +38,14 @@ function RuntimeError() {
 RuntimeError.prototype = Error.prototype;
 
 module.exports.RuntimeError = RuntimeError;
+
+function WrongArgumentError() {
+  var tmp = Error.apply(this, arguments);
+  tmp.name = this.name = 'WrongArgumentError';
+
+  this.stack = tmp.stack;
+  this.message = tmp.message;
+}
+WrongArgumentError.prototype = Error.prototype;
+
+module.exports.WrongArgumentError = WrongArgumentError;


### PR DESCRIPTION
This class was missing from exceptions.js while actually being used in
other parts of the code base (simplifier.js).

So I basically cloned the error class that was already in the file.

Please check this out, @roman-kaspar !
